### PR TITLE
uic-zigpc.service needs a working directory

### DIFF
--- a/applications/zigpc/scripts/systemd/uic-zigpc.service
+++ b/applications/zigpc/scripts/systemd/uic-zigpc.service
@@ -3,6 +3,7 @@ Description=Unify Zigbee Protocol Controller
 After=network.target mosquitto.service
 
 [Service]
+WorkingDirectory=/var/lib/uic
 ExecStart=/usr/bin/zigpc --conf /etc/uic/uic.cfg
 Restart=on-failure
 KillMode=mixed


### PR DESCRIPTION
Without a working directory specified, uic-zigpc will attempt to create files under root instead of a directory it has permissions for.
This results in the following error:

"
May 20 12:02:04 unify-xg1 zigpc[792]: 2022-May-20 12:02:04.203583 <W> [zigpc_ota_zigbee] Error accessing or creating folder for OTA with error code: -1; errno: 13 (Permission denied)
May 20 12:02:04 unify-xg1 zigpc[792]: 2022-May-20 12:02:04.203754 <C> [uic_component_fixtures] Failed  [1]: ZigPC OTA.
May 20 12:02:04 unify-xg1 systemd[1]: uic-zigpc.service: Main process exited, code=exited, status=1/FAILURE
"

Expected behavior - Systemd service has a specified working directory (like /var/lib/uic) in which the 'uic' user has write privileges.