### PR TITLE
ZPC crash with Terminate called after throwing an instance of 'nlohmann::detail::type_error'

### DIFF
--- a/components/uic_dotdot_mqtt/zap/dotdot_mqtt_cpp.zapt
+++ b/components/uic_dotdot_mqtt/zap/dotdot_mqtt_cpp.zapt
@@ -417,6 +417,11 @@ sl_status_t {{dotdot_prefix}}_{{asSnakeCaseLower parent.label}}_{{asSnakeCaseLow
     nlohmann::json json_object = nlohmann::json::object();
             {{#zcl_struct_items_by_struct_name type}}
     json_object["{{label}}"] = value[i].{{label}};
+    try {
+        std::string check = json_object["{{label}}"].dump();
+    } catch (const nlohmann::json::exception& e) {
+        sl_log_debug(LOG_TAG, LOG_FMT_JSON_ERROR, "{{parent.label}}", "{{label}}", e.what());
+    }
             {{/zcl_struct_items_by_struct_name}}
     jsn["value"].push_back(json_object);
           {{else}}
@@ -464,7 +469,13 @@ sl_status_t {{dotdot_prefix}}_{{asSnakeCaseLower parent.label}}_{{asSnakeCaseLow
 
   {{/if}}
 
-  std::string payload_str = jsn.dump();
+  std::string payload_str;
+  try {
+    payload_str = jsn.dump(-1, ' ', true, nlohmann::detail::error_handler_t::replace);
+  } catch (const nlohmann::json::exception& e) {
+    sl_log_debug(LOG_TAG, LOG_FMT_JSON_ERROR, "{{asPublicationName parent.label}}/Attributes/{{label}}", e.what());
+    return SL_STATUS_OK;
+  }
 
   {{#if_is_bitmap type}}
   boost::replace_all(payload_str, "\"true\"", "true");


### PR DESCRIPTION
If ConfigurationParameters::Info has characters > 0x7F like Degree sign 0xb0, or cent sign 0xa2,

ZPC will crash

Example device is Zooz 4-in-1 sensor

terminate called after throwing an instance of 'nlohmann::detail::type_error'
  what():  [json.exception.type_error.316] invalid UTF-8 byte at index 17: 0xA2
Aborted

catch exception, replace character and contiue:

[dotdot_mqtt] by-unid ConfigurationParameters::Info: Unable to parse JSON payload: [json.exception.type_error.316] invalid UTF-8 byte at index 17: 0xA2
[dotdot_mqtt] by-unid ConfigurationParameters::Info: Unable to parse JSON payload: [json.exception.type_error.316] invalid UTF-8 byte at index 17: 0xA2