### PR TITLE
Fix switch multilevel OnOff

### DIFF
--- a/applications/zpc/components/dotdot_mapper/rules/ColorControl_to_ColorSwitch.uam
+++ b/applications/zpc/components/dotdot_mapper/rules/ColorControl_to_ColorSwitch.uam
@@ -53,7 +53,7 @@ def zbON_OFF                    0x00060000
 // If we have a node with Binary Switch + Color Switch, we need to simulate
 // the Level cluster.
 def simulate_level (e'zwCOLOR_SWITCH_v & (e'zwMULTILEVEL_v==0))
-def simulate_on_off (e'zwCOLOR_SWITCH_v & (e'zwBINARY_SWITCH_v ==0))
+def simulate_on_off (e'zwCOLOR_SWITCH_v & (e'zwMULTILEVEL_v==0) & (e'zwBINARY_SWITCH_v ==0))
 
 // Intermediate calculations
 // Hue/Saturation/Level is just a lot easier than CieXY.


### PR DESCRIPTION
OnOff cluster commands do not work for multilevel switch.
Rule 
`r'zbON_OFF = if(simulate_on_off) d'zbON_OFF  undefined`
defined in ColorControl_to_ColorSwitch.uam
will result in  r'zbON_OFF being triggered on d'zbON_OFF change and effectively short-circuit and override rule
`d'zwSTATE.zwON_OFF = d'zbON_OFF_CLUSTER_ON_OFF`
defined in Level.uam, making former rule ignored.

