### PR TITLE
openthread_border_router: Remove empty "Boarder" chapter

### DIFF
--- a/applications/openthread_border_router/readme_user.md
+++ b/applications/openthread_border_router/readme_user.md
@@ -9,4 +9,3 @@ networks use the same 802.15.4 channel.
 
 To get started running OTBR with CPCd, see the
 [Multiprotocol Setup](../../doc/getting_started_multiprotocol_cpc.md) page.
-# OpenThread Boarder Router User Guide


### PR DESCRIPTION
    
    I assume it's a leftover mistake that could be removed
    or something to be reintroduced when complete.
    
    Forwarded: https://github.com/SiliconLabs/UnifySDK/pull/9
