### PR TITLE
After second consecutive NodeInterview, Attribute type 0x7106 (Event) will not get resolved for Push mode sensors.

### DIFF
--- a/applications/zpc/components/ucl_mqtt/src/ucl_mqtt_node_interview.c
+++ b/applications/zpc/components/ucl_mqtt/src/ucl_mqtt_node_interview.c
@@ -32,7 +32,10 @@
 void undefine_attribute_with_get_rule(attribute_store_node_t node)
 {
   if (attribute_resolver_has_get_rule(attribute_store_get_node_type(node))) {
-    attribute_store_undefine_reported(node);
+   // If node is already under resolution, we should just retry
+   if(SL_STATUS_NOT_FOUND == attribute_resolver_restart_get_resolution(node)) {
+        attribute_store_undefine_reported(node);
+   }
   }
 }
 


### PR DESCRIPTION
Endpoint will stay stuck in "Online Interviewing" state, until eventually device sends unsolicited Push Notification.