### PR TITLE
Rearranged the order of attribute to align with documentation.

### DIFF
--- a/applications/zpc/components/zcl_cluster_servers/src/zcl_OTA_cluster_server.cpp
+++ b/applications/zpc/components/zcl_cluster_servers/src/zcl_OTA_cluster_server.cpp
@@ -120,9 +120,9 @@ static sl_status_t get_target_info(attribute fw_target,
       = zw_node.child_by_type_and_value<uint8_t>(ATTRIBUTE_ENDPOINT_ID, 0);
     attribute manufacturer_id
       = ep0_node.child_by_type(ATTRIBUTE_MANUFACTURER_SPECIFIC_MANUFACTURER_ID);
-    attribute product_id
-      = ep0_node.child_by_type(ATTRIBUTE_MANUFACTURER_SPECIFIC_PRODUCT_TYPE_ID);
     attribute product_type_id
+      = ep0_node.child_by_type(ATTRIBUTE_MANUFACTURER_SPECIFIC_PRODUCT_TYPE_ID);
+    attribute product_id
       = ep0_node.child_by_type(ATTRIBUTE_MANUFACTURER_SPECIFIC_PRODUCT_ID);
     attribute version_report_node
       = ep0_node.child_by_type(ATTRIBUTE_CC_VERSION_VERSION_REPORT_DATA);

--- a/applications/zpc/components/zcl_cluster_servers/test/zcl_OTA_cluster_server_test.cpp
+++ b/applications/zpc/components/zcl_cluster_servers/test/zcl_OTA_cluster_server_test.cpp
@@ -68,8 +68,8 @@ void suiteSetUp()
   n5ep0.emplace_node<uint32_t>(ATTRIBUTE_MANUFACTURER_SPECIFIC_MANUFACTURER_ID,
                                0);
   n5ep0.emplace_node<uint32_t>(ATTRIBUTE_MANUFACTURER_SPECIFIC_PRODUCT_TYPE_ID,
-                               42);
-  n5ep0.emplace_node<uint32_t>(ATTRIBUTE_MANUFACTURER_SPECIFIC_PRODUCT_ID, 1);
+                               1);
+  n5ep0.emplace_node<uint32_t>(ATTRIBUTE_MANUFACTURER_SPECIFIC_PRODUCT_ID, 42);
 
   n5ep0.emplace_node<uint32_t>(ATTRIBUTE_CC_VERSION_VERSION_REPORT_DATA, 1)
     .emplace_node<uint32_t>(ATTRIBUTE_CC_VERSION_FIRMWARE, 0x1)


### PR DESCRIPTION
The names assigned to product_id and product_type_id seem to be potentially swapped or incorrectly named based on their attribute names.

As result UIID does not match with [documentation]( https://siliconlabs.github.io/UnifySDK/applications/zpc/readme_user.html?highlight=uiid#ota-uiid-construction).


The UIID for the ZPC is a string that can be constructed using the following information:

The Manufacturer ID (Manufacturer Specific Command Class, 2 bytes)
The Product Type (Manufacturer Specific Command Class, 2 bytes)
The Product ID (Manufacturer Specific Command Class, 2 bytes)
The Firmware Target (Firmware Update Command Class, 1 byte)
The Hardware version (Version Command Class, 1 byte) 