### PR TITLE
GH-22: Fix Multi Channel Handling of Secure NIF

### DIFF
--- a/applications/zpc/components/zwave_command_classes/test/zwave_command_class_node_info_resolver_test.c
+++ b/applications/zpc/components/zwave_command_classes/test/zwave_command_class_node_info_resolver_test.c
@@ -73,9 +73,9 @@ void attribute_resolver_set_resolution_give_up_listener_stub(
   attribute_resolver_callback_t callback,
   int cmock_num_calls)
 {
-  TEST_ASSERT_EQUAL(ATTRIBUTE_ZWAVE_NIF, node_type);
-  on_nif_resolution_abort = callback;
-  return;
+  if (ATTRIBUTE_ZWAVE_NIF == node_type) {
+    on_nif_resolution_abort = callback;
+  }
 }
 
 sl_status_t zwave_controller_register_callbacks_stub(


### PR DESCRIPTION
## Change
Some S0 multichannel endpoints will not respond to multichannel encapsulated SECURITY_COMMANDS_SUPPORTED_GET command [ 60 0D 00 01 98 02 ]. In such case, copy endpoint NIF to Secure NIF.

For reference, see document:
https://sdomembers.z-wavealliance.org/document/dl/652
Z-Wave Transport-Encapsulation Command Class Specification
3.5.4.1 Multi Channel Handling
Page 46

The implicit rule that all non-secure command classes for an End Point must be controllable securely is still in effect, if the endpoint is reported secure.

## Checklist
- [x] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


