### PR TITLE
GH-24: Fix CC SWITCH_COLOR Duration param

### DIFF
--- a/applications/zpc/components/zpc_rust/src/rust_command_handlers/zwave_command_classes/zwave_command_class_switch_color.rs
+++ b/applications/zpc/components/zpc_rust/src/rust_command_handlers/zwave_command_classes/zwave_command_class_switch_color.rs
@@ -327,9 +327,7 @@ fn switch_color_set(state_node: Attribute) -> Result<(sl_status_t, Vec<u8>), Att
             reserved: 0,
         },
         vg1: colors,
-        // FIXME: UIC-1926 This SwitchColorSetFrame wants a SwitchColorSetDurationEnum for
-        // the duration, which prevents me to use my duration found in the attribute store.
-        duration: SwitchColorSetDurationEnum::Instantly,
+        duration: _duration as u8,
     };
 
     Ok((SL_STATUS_OK, set_frame.into()))

--- a/applications/zpc/components/zwave_command_classes/assets/ZWave_custom_cmd_classes.xml
+++ b/applications/zpc/components/zwave_command_classes/assets/ZWave_custom_cmd_classes.xml
@@ -12970,7 +12970,10 @@
         <param key="0x00" name="Color Component ID" type="BYTE" />
         <param key="0x01" name="Value" type="BYTE" />
       </variant_group>
-      <param key="0x02" name="Duration" type="BYTE" />
+      <param key="0x02" name="Duration" type="BYTE">
+        <bitflag key="0x01" flagname="Instantly" flagmask="0x00" />
+        <bitflag key="0x02" flagname="Default" flagmask="0xFF" />
+      </param>
     </cmd>
     <cmd key="0x06" name="SWITCH_COLOR_START_LEVEL_CHANGE" help="Color Switch Start Level Change" support_mode="RX">
       <param key="0x00" name="Properties1" type="STRUCT_BYTE">
@@ -12998,10 +13001,10 @@
       <param key="0x00" name="Color Component ID" type="BYTE" />
       <param key="0x01" name="Current Value" type="BYTE" />
       <param key="0x02" name="Target Value" type="BYTE" />
-      <param key="0x03" name="Duration" type="CONST">
-        <const key="0x00" flagname="Already at the Target Value" flagmask="0x00" />
-        <const key="0x01" flagname="Unknown duration" flagmask="0xFE" />
-        <const key="0x02" flagname="Reserved" flagmask="0xFF" />
+      <param key="0x03" name="Duration" type="BYTE">
+        <bitflag key="0x00" flagname="Already at the Target Value" flagmask="0x00" />
+        <bitflag key="0x01" flagname="Unknown duration" flagmask="0xFE" />
+        <bitflag key="0x02" flagname="Reserved" flagmask="0xFF" />
       </param>
     </cmd>
     <cmd key="0x05" name="SWITCH_COLOR_SET" help="Color Switch Set" support_mode="RX">
@@ -13013,9 +13016,9 @@
         <param key="0x00" name="Color Component ID" type="BYTE" />
         <param key="0x01" name="Value" type="BYTE" />
       </variant_group>
-      <param key="0x02" name="Duration" type="CONST">
-        <const key="0x00" flagname="Instantly" flagmask="0x00" />
-        <const key="0x01" flagname="Default" flagmask="0xFF" />
+      <param key="0x02" name="Duration" type="BYTE">
+        <bitflag key="0x01" flagname="Instantly" flagmask="0x00" />
+        <bitflag key="0x02" flagname="Default" flagmask="0xFF" />
       </param>
     </cmd>
     <cmd key="0x06" name="SWITCH_COLOR_START_LEVEL_CHANGE" help="Color Switch Start Level Change" support_mode="RX">
@@ -13027,9 +13030,9 @@
       </param>
       <param key="0x01" name="Color Component ID" type="BYTE" />
       <param key="0x02" name="Start Level" type="BYTE" />
-      <param key="0x03" name="Duration" type="CONST">
-        <const key="0x00" flagname="Instantly" flagmask="0x00" />
-        <const key="0x01" flagname="Default" flagmask="0xFF" />
+      <param key="0x03" name="Duration" type="BYTE">
+        <bitflag key="0x01" flagname="Instantly" flagmask="0x00" />
+        <bitflag key="0x02" flagname="Default" flagmask="0xFF" />
       </param>
     </cmd>
     <cmd key="0x07" name="SWITCH_COLOR_STOP_LEVEL_CHANGE" help="Color Switch Stop Level Change" support_mode="RX">

--- a/applications/zpc/components/zwave_command_classes/src/zwave_command_class_switch_color.c
+++ b/applications/zpc/components/zwave_command_classes/src/zwave_command_class_switch_color.c
@@ -37,9 +37,9 @@
 
 #define LOG_TAG "zwave_command_class_switch_color"
 
-[[maybe_unused]]
-static void set_desired_duration(attribute_store_node_t state_node,
-                                 uint32_t duration)
+static void set_duration(attribute_store_node_t state_node,
+                         attribute_store_node_value_state_t state,
+                         uint32_t duration)
 {
   attribute_store_node_t duration_node
     = attribute_store_get_first_child_by_type(
@@ -47,21 +47,7 @@ static void set_desired_duration(attribute_store_node_t state_node,
       ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_DURATION);
 
   attribute_store_set_node_attribute_value(duration_node,
-                                           DESIRED_ATTRIBUTE,
-                                           (uint8_t *)&duration,
-                                           sizeof(duration));
-}
-
-static void set_reported_duration(attribute_store_node_t state_node,
-                                  uint32_t duration)
-{
-  attribute_store_node_t duration_node
-    = attribute_store_get_first_child_by_type(
-      state_node,
-      ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_DURATION);
-
-  attribute_store_set_node_attribute_value(duration_node,
-                                           REPORTED_ATTRIBUTE,
+                                           state,
                                            (uint8_t *)&duration,
                                            sizeof(duration));
 }
@@ -80,15 +66,7 @@ static void
   while (component_node != ATTRIBUTE_STORE_INVALID_NODE) {
     index += 1;
 
-    attribute_store_node_t duration_node
-      = attribute_store_get_first_child_by_type(
-        component_node,
-        ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_DURATION);
-
-    attribute_store_set_node_attribute_value(duration_node,
-                                             value_state,
-                                             (uint8_t *)&duration,
-                                             sizeof(duration));
+    set_duration(component_node, value_state, duration);
 
     component_node = attribute_store_get_node_child_by_type(
       state_node,
@@ -166,7 +144,7 @@ static void
         state_node,
         ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_VALUE,
         &attribute_store_undefine_desired);
-      set_reported_duration(state_node, 0);
+      set_duration(state_node, REPORTED_ATTRIBUTE, 0);
       attribute_store_undefine_desired(duration_node);
       break;
 

--- a/applications/zpc/components/zwave_command_classes/src/zwave_command_class_switch_color.c
+++ b/applications/zpc/components/zwave_command_classes/src/zwave_command_class_switch_color.c
@@ -24,6 +24,7 @@
 #include "attribute_store_defined_attribute_types.h"
 #include "ZW_classcmd.h"
 #include "zpc_attribute_resolver.h"
+#include "zwave_command_classes_utils.h"
 
 // Includes from other Unify Components
 #include "dotdot_mqtt.h"
@@ -34,6 +35,38 @@
 #include "attribute_timeouts.h"
 #include "sl_log.h"
 
+#define LOG_TAG "zwave_command_class_switch_color"
+
+[[maybe_unused]]
+static void set_desired_duration(attribute_store_node_t state_node,
+                                 uint32_t duration)
+{
+  attribute_store_node_t duration_node
+    = attribute_store_get_first_child_by_type(
+      state_node,
+      ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_DURATION);
+
+  attribute_store_set_node_attribute_value(duration_node,
+                                           DESIRED_ATTRIBUTE,
+                                           (uint8_t *)&duration,
+                                           sizeof(duration));
+}
+
+static void set_reported_duration(attribute_store_node_t state_node,
+                                  uint32_t duration)
+{
+  attribute_store_node_t duration_node
+    = attribute_store_get_first_child_by_type(
+      state_node,
+      ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_DURATION);
+
+  attribute_store_set_node_attribute_value(duration_node,
+                                           REPORTED_ATTRIBUTE,
+                                           (uint8_t *)&duration,
+                                           sizeof(duration));
+}
+
+[[maybe_unused]]
 static void
   set_all_color_switch_durations(attribute_store_node_t state_node,
                                  attribute_store_node_value_state_t value_state,
@@ -64,6 +97,34 @@ static void
   }
 }
 
+static void switch_color_undefine_reported(attribute_store_node_t state_node)
+{
+  zwave_command_class_switch_color_invoke_on_all_attributes_with_return_value(
+    state_node,
+    ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_VALUE,
+    attribute_stop_transition);
+
+  attribute_store_node_t duration_node
+      = attribute_store_get_first_child_by_type(
+        state_node,
+        ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_DURATION);
+  color_component_id_duration_t duration = 0;
+  attribute_store_undefine_desired(duration_node);
+  attribute_store_set_reported(duration_node,
+                               &duration,
+                               sizeof(duration));
+
+  sl_log_debug(LOG_TAG, "Transition time expired, probe color");
+  zwave_command_class_switch_color_invoke_on_all_attributes(
+    state_node,
+    ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_VALUE,
+    attribute_store_undefine_desired);
+  zwave_command_class_switch_color_invoke_on_all_attributes(
+    state_node,
+    ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_VALUE,
+    attribute_store_undefine_reported);
+}
+
 // FIXME: UIC-1901 This function belongs to zwave_command_class_switch_color.rs, but this
 // component really cannot interact with the attribute resolver.
 static void
@@ -78,12 +139,22 @@ static void
     return;
   }
 
+  attribute_store_node_t duration_node
+      = attribute_store_get_first_child_by_type(
+        state_node,
+        ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_DURATION);
+
+  color_component_id_duration_t duration = 0;
+  attribute_store_get_desired(duration_node,
+                              &duration,
+                              sizeof(duration));
+
+  clock_time_t zwave_desired_duration
+    = zwave_duration_to_time((uint8_t)duration);
+
   switch (event) {
     case FRAME_SENT_EVENT_OK_SUPERVISION_WORKING:
-      zwave_command_class_switch_color_invoke_on_all_attributes_with_return_value(
-        state_node,
-        ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_DURATION,
-        &attribute_store_set_reported_as_desired);
+      attribute_store_set_reported_as_desired(duration_node);
       break;
 
     case FRAME_SENT_EVENT_OK_SUPERVISION_SUCCESS:
@@ -95,11 +166,44 @@ static void
         state_node,
         ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_VALUE,
         &attribute_store_undefine_desired);
-      set_all_color_switch_durations(state_node, REPORTED_ATTRIBUTE, 0);
-      set_all_color_switch_durations(state_node, DESIRED_ATTRIBUTE, 0);
+      set_reported_duration(state_node, 0);
+      attribute_store_undefine_desired(duration_node);
       break;
 
-    // FRAME_SENT_EVENT_OK_NO_SUPERVISION:
+    case FRAME_SENT_EVENT_OK_NO_SUPERVISION:
+      zwave_command_class_switch_color_invoke_on_all_attributes_with_return_value(
+        state_node,
+        ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_VALUE,
+        attribute_stop_transition);
+      if(zwave_desired_duration > 0) {
+        // Should we estimate reported color values during transition
+        // and publish them as reported, like we did for level cluster?
+
+        zwave_command_class_switch_color_invoke_on_all_attributes(
+          state_node,
+          ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_VALUE,
+          attribute_store_undefine_desired);
+
+        attribute_store_set_reported_as_desired(duration_node);
+        attribute_store_undefine_desired(duration_node);
+
+        // Probe again after this duration
+        attribute_timeout_set_callback(state_node,
+                                       zwave_desired_duration + PROBE_BACK_OFF,
+                                       &switch_color_undefine_reported);
+      } else {
+        zwave_command_class_switch_color_invoke_on_all_attributes(
+          state_node,
+          ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_VALUE,
+          attribute_store_undefine_desired);
+        zwave_command_class_switch_color_invoke_on_all_attributes(
+          state_node,
+          ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_VALUE,
+          attribute_store_undefine_reported);
+        attribute_store_undefine_desired(duration_node);
+      }
+      break;
+
     // FRAME_SENT_EVENT_OK_SUPERVISION_NO_SUPPORT:
     // FRAME_SENT_EVENT_OK_SUPERVISION_FAIL:
     default:
@@ -115,14 +219,8 @@ static void
         state_node,
         ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_VALUE,
         &attribute_store_undefine_reported);
-      zwave_command_class_switch_color_invoke_on_all_attributes(
-        state_node,
-        ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_DURATION,
-        &attribute_store_undefine_desired);
-      zwave_command_class_switch_color_invoke_on_all_attributes(
-        state_node,
-        ATTRIBUTE_COMMAND_CLASS_SWITCH_COLOR_DURATION,
-        &attribute_store_undefine_reported);
+      attribute_store_undefine_desired(duration_node);
+      attribute_store_undefine_reported(duration_node);
       break;
   }
 


### PR DESCRIPTION
## Change
CC SWITCH_COLOR Duration can be any value in the range 0x01..0xFD.

For reference, see:
CC:0000.00.00.11.015
CC:0033.02.05.11.007
This fix depends on: https://github.com/Z-Wave-Alliance/zwave_xml/pull/12

## Checklist
- [x] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


