### PR TITLE
GH-26: Fix infinite loop on invalid next configuration parameter.

### DIFF
--- a/applications/zpc/components/zwave_command_classes/src/zwave_command_class_configuration_control.c
+++ b/applications/zpc/components/zwave_command_classes/src/zwave_command_class_configuration_control.c
@@ -723,6 +723,16 @@ static sl_status_t
   if (frame_length >= (current_index + 2)) {
     next_id = (configuration_parameter_id_t)((frame[current_index] << 8)
                                              | frame[current_index + 1]);
+    if (next_id == parameter_id) {
+      sl_log_debug(LOG_TAG,
+                   "NodeID %d:%d reports that next parameter number %d"
+                   "equals the current one %d, ignoring.",
+                   info->remote.node_id,
+                   info->remote.endpoint_id,
+                   next_id,
+                   parameter_id);
+      next_id = 0;
+    }
     // Indicate the next parameter to search for:
     attribute_store_set_desired(next_id_node, &next_id, sizeof(next_id));
     // Set the reported, then undefine it so the resolver tries a new get immediately.


### PR DESCRIPTION
When 'Parameter Number' and 'Next Parameter Number' are equal, configuration parameter discovery can not complete.
For example, this RX Z-Wave frame will set Node Interview into an infinite loop:

70 : COMMAND_CLASS_CONFIGURATION
0F : CONFIGURATION_PROPERTIES_REPORT_V4
00 : Parameter Number 1 (MSB)
71 : Parameter Number 2 (LSB)
09 : Format 0x01 Unsigned Integer, size 0x1
01 : Min Value
64 : Max Value
0A : Default Value
00 : Next Parameter Number (MSB)
71 : Next Parameter Number (LSB)
02 : No Bulk support 0x1, Not Advanced Parameter 0x0

## Change
Detect case when next and current parameter numbers match and exit discovery loop.

## Checklist
- [x] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


