### PR TITLE
GH-40: MAX_PING_TIME_INTERVAL should be 24 hours, 24 not minutes

### DIFF
--- a/applications/zpc/components/network_monitor/src/failing_node_monitor.cpp
+++ b/applications/zpc/components/network_monitor/src/failing_node_monitor.cpp
@@ -136,6 +136,10 @@ static void
     ping_interval = MAX_PING_TIME_INTERVAL;
   }
 
+  sl_log_debug(LOG_TAG,
+               "Scheduling NOP command in %lu ms for NodeID: %d.",
+               ping_interval,
+               node_id);
   attribute_store_set_reported(ping_interval_node,
                                &ping_interval,
                                sizeof(ping_interval));

--- a/applications/zpc/components/network_monitor/src/failing_node_monitor.h
+++ b/applications/zpc/components/network_monitor/src/failing_node_monitor.h
@@ -50,7 +50,7 @@
 #define FL_NODE_PING_TIME_FACTOR 4
 
 // Maximum time we settle on between ping intervals:
-#define MAX_PING_TIME_INTERVAL (24 * 60 * CLOCK_SECOND)
+#define MAX_PING_TIME_INTERVAL (24 * 60 * 60 * CLOCK_SECOND) // 24 hours
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
In ver_1.0.0 intended value was supposed to be 24 hours, as indicated by its comment. During refactoring this comment was lost, so value incorrectly remained 24 minutes. Interval of 24 minutes to ping failing device seems arbitrary and too short.