### PR TITLE
Refactor/reuse sapi parser on zgw

### DIFF
--- a/scripts/serial_decode_zpc.py
+++ b/scripts/serial_decode_zpc.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# SPDX-License-Identifier: LicenseRef-MSLA
+# SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
 '''
 Created on 08/11/2011
 

--- a/scripts/serial_decode_zpc.py
+++ b/scripts/serial_decode_zpc.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: LicenseRef-MSLA
 # SPDX-FileCopyrightText: Silicon Laboratories Inc. https://www.silabs.com
 '''
+The script was replicated and updated to work with Z/IP Gateway
+See https://github.com/SiliconLabs/zipgateway/pull/30
+
 Created on 08/11/2011
 
 @author: aes


### PR DESCRIPTION
## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

The [script to decode the SAPI logs](https://github.com/SiliconLabs/UnifySDK/blob/ver_1.6.0/scripts/serial_decode_zpc.py) is being reused by the ZGW project. This PR adds legal information to the script, as well as a reference to the location in the ZGW project.

Related-to: https://github.com/SiliconLabs/zipgateway/pull/30

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


