### PR TITLE
SWPROT-8953: Add recipe to pull UnifySDK dependency

### DIFF
--- a/cmake/modules/FindUnifySDK.cmake
+++ b/cmake/modules/FindUnifySDK.cmake
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Silicon Laboratories Inc. <https://www.silabs.com/>
+# SPDX-License-Identifier: Zlib
+
+# This recipe allows to download Unify Core
+# Origin: https://github.com/SiliconLabs/UnifySDK/pulls?q=is%3Apr+author%3Arzr
+# It can be used by projects which are depending on it
+# Feel free to copy this (up to date) file everywhere it is needed
+
+include(FetchContent)
+
+# Standard cmake paths, you probably don't want/need to change
+if(NOT DEFINED UNIFYSDK_SOURCE_DIR)
+  set(UNIFYSDK_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/unifysdk-src")
+endif()
+if(NOT DEFINED UNIFYSDK_BINARY_DIR)
+  set(UNIFYSDK_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/unifysdk-build") # TODO
+endif()
+
+if(NOT DEFINED UNIFYSDK_GIT_REPOSITORY)
+  if(DEFINED ENV{UNIFYSDK_GIT_REPOSITORY})
+    set(UNIFYSDK_GIT_REPOSITORY $ENV{UNIFYSDK_GIT_REPOSITORY})
+  else()
+    set(UNIFYSDK_GIT_REPOSITORY "")
+  endif()
+endif()
+if(UNIFYSDK_GIT_REPOSITORY STREQUAL "")
+  set(UNIFYSDK_GIT_REPOSITORY "https://github.com/SiliconLabs/UnifySDK")
+endif()
+
+if(NOT DEFINED UNIFYSDK_GIT_TAG)
+  if(DEFINED ENV{UNIFYSDK_GIT_TAG})
+    set(UNIFYSDK_GIT_TAG $ENV{UNIFYSDK_GIT_TAG})
+  else()
+    set(UNIFYSDK_GIT_TAG "")
+  endif()
+endif()
+
+if(UNIFYSDK_GIT_TAG STREQUAL "")
+  set(UNIFYSDK_GIT_TAG "main")
+endif()
+
+FetchContent_Declare(
+  UnifySDK
+  GIT_REPOSITORY ${UNIFYSDK_GIT_REPOSITORY}
+  GIT_TAG        ${UNIFYSDK_GIT_TAG}
+  GIT_SUBMODULES_RECURSE True
+  GIT_SHALLOW 1
+)
+
+message(STATUS "${CMAKE_PROJECT_NAME}: Depends: ${UNIFYSDK_GIT_REPOSITORY}#${UNIFYSDK_GIT_TAG}")
+message(STATUS "UnifySDK Sources: ${UNIFYSDK_SOURCE_DIR}")
+message(STATUS "UnifySDK Binaries: ${UNIFYSDK_BINARY_DIR}")
+
+# Pull only once, this has be refreshed by developer
+if(NOT EXISTS ${CMAKE_BINARY_DIR}/_deps/unifysdk-src)
+  if(UNIFYSDK_GIT_TAG STREQUAL "main")
+    message(WARNING "Using: ${UNIFYSDK_GIT_TAG} TODO: Pin stable revision once supported")
+  endif()
+  FetchContent_MakeAvailable(UnifySDK)
+else()
+  message(STATUS "Using UnifySDK from previous fetch (may be outdated)")
+  add_subdirectory(${CMAKE_BINARY_DIR}/_deps/unifysdk-src)
+endif()


### PR DESCRIPTION
This file is shared a single commit,
to allow pick between projects (eg: z-wave-protocol-controller) consuming UnifySDK since the monorepo has been shrinked. Feedback welcome.

Note values can be ajusted from env,
it can be usefull for github actions with fork,
if using private one make sure to pass the token in the build env:

    UNIFYSDK_GIT_REPOSITORY="https://<TOKEN>@github.com/rzr/UnifySDK"

Bug-SiliconLabs: SWPROT-8953
Origin: https://github.com/SiliconLabs/UnifySDK/pulls?q=is%3Apr+author%3Arzr
Forwarded: https://github.com/SiliconLabsSoftware/unify-z-wave/pulls

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


