### PR TITLE
contiki: Clear events pointer once consummed

### DIFF
--- a/components/uic_contiki/core/sys/process.c
+++ b/components/uic_contiki/core/sys/process.c
@@ -313,6 +313,7 @@ static void do_event(void) CC_REENTRANT_ARG
 
     data     = events[fevent].data;
     receiver = events[fevent].p;
+    int fevent_copy = fevent; /* To be cleared once processed */
 
     /* Since we have seen the new event, we move pointer upwards
        and decrese the number of events. */
@@ -342,6 +343,9 @@ static void do_event(void) CC_REENTRANT_ARG
       /* Make sure that the process actually is running. */
       call_process(receiver, ev, data);
     }
+    /* Clear pointer (to potentially unreachable/freed data) */
+    events[fevent_copy].data = NULL;
+    events[fevent_copy].p = NULL;
   }
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This prevent potential access to invalid address,
typically after a deletion.

This change should be forwarded upstream, once contiki dependency is managed in modular way (using ref to upstream not code dump).

Relate-to: https://github.com/SiliconLabsSoftware/z-wave-protocol-controller/pull/94
Relate-to: UIC-3659
Relate-to: https://github.com/SiliconLabsSoftware/z-wave-engine-application-layer/issues/17

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [ ] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


